### PR TITLE
force networkx install to be 1.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python=2.7
 - matplotlib
-- networkx
+- networkx=1.*
 - numpy
 - jupyter
 - ipykernel


### PR DESCRIPTION
As noted in #31 NetworkX 2.0 has been released and the notebooks are not compatible with this new version. If one creates an environment using the ```environment.yml``` file, they will get NetworkX 2.0.
Until the notebooks are upgraded to work with 1.X and 2.0 this forces the installation of NetworkX 1.X.