### PR TITLE
Fix typo (ring lattice has 10 nodes)

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2125,7 +2125,7 @@ Figure~\ref{chap03-1} shows the result.
 
 \begin{figure}
 \centerline{\includegraphics[width=3.5in]{figs/chap03-2.pdf}}
-\caption{WS graphs with $n=20$, $k=4$, and $p=0$ (left), $p=0.2$ (middle),
+\caption{WS graphs with $n=10$, $k=4$, and $p=0$ (left), $p=0.2$ (middle),
 and $p=1$ (right).}
 \label{chap03-2}
 \end{figure}
@@ -2188,7 +2188,7 @@ This function does not consider the edges in the order specified
 by Watts and Strogatz, but that doesn't seem to affect
 the results.
 
-Figure~\ref{chap03-2} shows WS graphs with $n=20$, $k=4$, and
+Figure~\ref{chap03-2} shows WS graphs with $n=10$, $k=4$, and
 a range of values of $p$.  When $p=0$, the graph is a ring lattice.
 When $p=1$, it is completely random.  As we'll see, the interesting
 things happen in between.


### PR DESCRIPTION
The descriptions of Figure 3.2 state that "n = 20" but the graphs only have 10 nodes.