### PR TITLE
Fix bug in path_lengths

### DIFF
--- a/code/chap03.ipynb
+++ b/code/chap03.ipynb
@@ -499,7 +499,8 @@
     "    length_iter = nx.shortest_path_length(G)\n",
     "    for source, dist_map in length_iter:\n",
     "        for dest, dist in dist_map.items():\n",
-    "            yield dist"
+    "            if source != dest:\n",
+    "                yield dist"
    ]
   },
   {

--- a/code/chap03soln.ipynb
+++ b/code/chap03soln.ipynb
@@ -643,7 +643,8 @@
     "    length_iter = nx.shortest_path_length(G)\n",
     "    for source, dist_map in length_iter:\n",
     "        for dest, dist in dist_map.items():\n",
-    "            yield dist"
+    "            if source != dest:\n",
+    "                yield dist"
    ]
   },
   {
@@ -678,7 +679,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9"
+       "1.0"
       ]
      },
      "execution_count": 24,


### PR DESCRIPTION
As it's written, `path_lengths` returns all distances, including the one from the source to itself. Assuming that shouldn't be the case, as the solutions indicate the average path length should be 1.