### PR TITLE
Remove duplicate definition of Methuselahs chap06

### DIFF
--- a/notebooks/chap06.ipynb
+++ b/notebooks/chap06.ipynb
@@ -316,9 +316,7 @@
     "python LifeRabbits.py\n",
     "```\n",
     "\n",
-    "Patterns that take a long time to reach steady state are called [Methuselahs](https://en.wikipedia.org/wiki/Methuselah_(cellular_automaton))\n",
-    "\n",
-    "Patterns like these prompted Conway's conjecture, which asks whether there are any initial conditions where the number of live cells is unbounded."
+    "Methuselahs like these prompted Conway's conjecture, which asks whether there are any initial conditions where the number of live cells is unbounded."
    ]
   },
   {


### PR DESCRIPTION
The chap06 notebook introduces Methuselahs (and links to Wikipedia) twice. I removed the second definition.